### PR TITLE
Adds support for 'mode' parameter and updates dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Creates a new Payto instance from a payto URL string.
 | `lang` | `string \| null` | Language/locale code (2-letter language code, e.g., 'en', 'en-US', 'en-us', 'fr-CA') |
 | `location` | `string \| null` | Location data (format depends on void type) |
 | `message` | `string \| null` | Payment message |
+| `mode` | `string \| null` | Preferred mode of Pass (e.g., 'qr', 'nfc') |
 | `network` | `string` | Network identifier (case-insensitive) |
 | `organization` | `string \| null` | Organization name (maximum 25 characters) |
 | `origin` | `string \| null` | URL origin |
@@ -192,7 +193,7 @@ The library includes TypeScript type definitions and runtime validation for:
 - Routing numbers (9 digits)
 - Account numbers (7-14 digits)
 - Email addresses (for UPI/PIX, case-insensitive)
-- Geographic coordinates
+- Geographic coordinates (up to 9 decimal places)
 - Plus codes
 - Unix timestamps
 - Barcode formats

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "payto-rl",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "PayTo Resource Locator",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -48,7 +48,7 @@
     ".": "./dist/index.js"
   },
   "devDependencies": {
-    "@types/node": "^24.1.0",
+    "@types/node": "^24.2.1",
     "c8": "^10.1.3",
     "esm": "^3.2.25",
     "ts-node": "^10.9.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ export type PaytoJSON = {
 	lang?: string | null;
 	location?: string | null;
 	message?: string | null;
+	mode?: string | null;
 	network?: string;
 	organization?: string | null;
 	origin?: string | null;
@@ -50,7 +51,7 @@ class Payto {
 	private static readonly EMAIL_REGEX = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
 
 	/** Validates geographic coordinates */
-	private static readonly GEO_LOCATION_REGEX = /^(\+|-)?(?:90(?:\.0{1,6})?|(?:[0-9]|[1-8][0-9])(?:\.[0-9]{1,6})?),(\+|-)?(?:180(?:\.0{1,6})?|(?:[0-9]|[1-9][0-9]|1[0-7][0-9])(?:\.[0-9]{1,6})?)$/;
+	private static readonly GEO_LOCATION_REGEX = /^(\+|-)?(?:90(?:\.0{1,9})?|(?:[0-9]|[1-8][0-9])(?:\.[0-9]{1,9})?),(\+|-)?(?:180(?:\.0{1,9})?|(?:[0-9]|[1-9][0-9]|1[0-7][0-9])(?:\.[0-9]{1,9})?)$/;
 
 	/** Validates IBAN */
 	private static readonly IBAN_REGEX = /^[A-Z]{2}[0-9]{2}[A-Z0-9]{12,30}$/i;
@@ -922,6 +923,20 @@ class Payto {
 		}
 	}
 
+	/** Gets preferred mode of Pass */
+	get mode(): string | null {
+		return this.searchParams.get('mode')?.toLowerCase() || null;
+	}
+
+	/** Sets preferred mode of Pass */
+	set mode(value: string | null) {
+		if (value) {
+			this.searchParams.set('mode', value.toLowerCase());
+		} else {
+			this.searchParams.delete('mode');
+		}
+	}
+
 	/** Converts to URL string */
 	toString(): string {
 		return this.url.toString();
@@ -968,6 +983,7 @@ class Payto {
 		if (this.lang) obj.lang = this.lang;
 		if (this.location) obj.location = this.location;
 		if (this.message) obj.message = this.message;
+		if (this.mode) obj.mode = this.mode;
 		if (this.network) obj.network = this.network;
 		if (this.organization) obj.organization = this.organization;
 		if (this.receiverName) obj.receiverName = this.receiverName;

--- a/test/paytoRl.test.ts
+++ b/test/paytoRl.test.ts
@@ -114,6 +114,15 @@ test('get and set location with geo coordinates', () => {
 	const payto = new Payto('payto://void/geo');
 	payto.location = '51.5074,0.1278';
 	assert.is(payto.location, '51.5074,0.1278');
+
+	// Test coordinates with 9 decimal places
+	payto.location = '51.507400000,0.127800000';
+	assert.is(payto.location, '51.507400000,0.127800000');
+
+	// Test coordinates with mixed decimal places
+	payto.location = '40.712800000,-74.006000000';
+	assert.is(payto.location, '40.712800000,-74.006000000');
+
 	assert.throws(() => {
 		payto.location = '91.0000,0.1278'; // Invalid latitude
 	}, /Invalid geo location format/);
@@ -467,6 +476,53 @@ test('handle RTL and donate flags', () => {
 	assert.is(payto.donate, true);
 	payto.donate = null;
 	assert.is(payto.donate, null);
+});
+
+test('get and set mode', () => {
+	const payto = new Payto('payto://xcb/address?mode=nfc');
+	assert.is(payto.mode, 'nfc');
+	payto.mode = 'qr';
+	assert.is(payto.mode, 'qr');
+	payto.mode = 'NFC';
+	assert.is(payto.mode, 'nfc');
+	payto.mode = null;
+	assert.is(payto.mode, null);
+});
+
+test('mode case handling', () => {
+	const payto = new Payto('payto://xcb/address');
+
+	// Test case conversion
+	payto.mode = 'NFC';
+	assert.is(payto.mode, 'nfc');
+
+	payto.mode = 'QR';
+	assert.is(payto.mode, 'qr');
+
+	payto.mode = 'Bluetooth';
+	assert.is(payto.mode, 'bluetooth');
+});
+
+test('mode in toJSONObject', () => {
+	const payto = new Payto('payto://xcb/address?mode=nfc');
+	const json = payto.toJSONObject();
+	assert.is(json.mode, 'nfc');
+
+	payto.mode = null;
+	const jsonWithoutMode = payto.toJSONObject();
+	assert.is(jsonWithoutMode.mode, undefined);
+});
+
+test('mode with other parameters', () => {
+	const payto = new Payto('payto://xcb/address?amount=10&mode=nfc&fiat=eur');
+	assert.is(payto.mode, 'nfc');
+	assert.is(payto.amount, '10');
+	assert.is(payto.fiat, 'eur');
+
+	payto.mode = 'qr';
+	assert.is(payto.mode, 'qr');
+	assert.is(payto.amount, '10');
+	assert.is(payto.fiat, 'eur');
 });
 
 test('handle path parts operations', () => {


### PR DESCRIPTION
Adds support for the 'mode' parameter in Payto URLs, allowing specification of preferred pass modes (e.g., 'qr', 'nfc').

Also, updates the `@types/node` dependency to the latest version and allows geographic coordinates to have up to 9 decimal places.